### PR TITLE
Update to Jenkins 2.426 LTS baseline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>2.414.3</jenkins.version>
+        <jenkins.version>2.426.1</jenkins.version>
     </properties>
 
     <name>Pool Node Config</name>
@@ -106,7 +106,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.414.x</artifactId>
+                <artifactId>bom-2.426.x</artifactId>
                 <version>2839.v003b_4d9d24fd</version>
                 <scope>import</scope>
                 <type>pom</type>


### PR DESCRIPTION
Update to Jenkins 2.426 LTS baseline.