### PR TITLE
Require Jenkins 2.426.3 LTS version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>2.426.1</jenkins.version>
+        <jenkins.version>2.426.3</jenkins.version>
     </properties>
 
     <name>Pool Node Config</name>


### PR DESCRIPTION
Dependencies start requiring it.