### PR TITLE
Update Security Scan to Java 21

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -19,4 +19,4 @@ jobs:
     name: jenkins-security-scan
     with:
       java-cache: 'maven'
-      java-version: 11
+      java-version: 21


### PR DESCRIPTION
Java 11 will be EOL in the not too far future.